### PR TITLE
easier startup & simplify environment variables

### DIFF
--- a/Scripts/smoke-test.sh
+++ b/Scripts/smoke-test.sh
@@ -13,12 +13,12 @@ mkdir -p "$output"
 
 socket_path="$tmpdir/swipr.sock"
 
-SWIPR_SAMPLING_SERVER_URL=unix://"$socket_path" \
+PROFILE_RECORDER_SERVER_URL=unix://"$socket_path" \
     "$tmpdir"/build/release/swipr-mini-demo \
     --blocking --burn-cpu --array-appends \
     --output "$output"/samples.swipr \
     --iterations 1000 \
-    --sampling-server &
+    --profiling-server &
 demo_pid=$!
 sleep 3
 

--- a/Sources/ProfileRecorder/Documentation.docc/Documentation.md
+++ b/Sources/ProfileRecorder/Documentation.docc/Documentation.md
@@ -16,7 +16,7 @@ ProfileRecorderSampler.sharedInstance.requestSamples(
 ```
 
 The example above creates 1000 samples with 10 ms between each sample. With this configuration, 
-the sampling server will capture samples over about 10 seconds.
+the profile recording server will capture samples over about 10 seconds.
 After that, you'll need to (on the machine you're running it) convert the samples into a regular format and symbolicate it.
 
 Optionally, you can have `llvm-symbolizer` symbolise your samples.

--- a/Sources/ProfileRecorder/ProfileRecorderSampler.swift
+++ b/Sources/ProfileRecorder/ProfileRecorderSampler.swift
@@ -58,17 +58,6 @@ public final class ProfileRecorderSampler: Sendable {
         #endif
     }
     
-    public static var _isSupportedPlatformForTesting: Bool{
-        if Self.isSupportedPlatform {
-            return true
-        }
-        #if os(iOS)
-        return true
-        #else
-        return false
-        #endif
-    }
-
     fileprivate init() {
         self.threadPool = NIOThreadPool(numberOfThreads: 1)
         self.threadPool.start()

--- a/Sources/ProfileRecorderServer/Documentation.docc/Documentation.md
+++ b/Sources/ProfileRecorderServer/Documentation.docc/Documentation.md
@@ -11,13 +11,13 @@ This enables you to capture profile traces in situations where you don't have ac
 You can pull it in as a fully self-contained Swift Package Manger dependency and then use it for your app.
 
 The easiest way to use Swift Profile Recorder in your application is to have it run the Swift Profile Recorder Server.
-With the sampling server running, retrieve symbolicated samples with a single `curl` (or any other HTTP client) command.
+With the profile recording server running, retrieve symbolicated samples with a single `curl` (or any other HTTP client) command.
 
 ### Quick Start
 
 Once you have bootstraped the Swift Profile Recorder Server in your application, request samples:
 
-1. Set the environment variable `SWIPR_SAMPLING_SERVER_URL=http://127.0.0.1:7377` and run your server
+1. Set the environment variable `PROFILE_RECORDER_SERVER_URL=http://127.0.0.1:7377` and run your server
 2. Request the samples using the host and port that you defined in the environment variable:
 
 ```bash
@@ -25,7 +25,7 @@ curl -sd '{"numberOfSamples":100,"timeInterval":"10 ms"}' http://localhost:7377 
     swift demangle --simplified > /tmp/samples.perf
 ```
 
-The sampling server can also provide access to traces over a UNIX domain socket. For more information, see <doc:ProfileRecorderServer/ProfileRecorderServer>.
+The profile recording server can also provide access to traces over a UNIX domain socket. For more information, see <doc:ProfileRecorderServer/ProfileRecorderServer>.
 
 ## Topics
 

--- a/Sources/ProfileRecorderServer/Documentation.docc/Reference/ProfileRecorderServer-ServerInfo.md
+++ b/Sources/ProfileRecorderServer/Documentation.docc/Reference/ProfileRecorderServer-ServerInfo.md
@@ -2,7 +2,7 @@
 
 ## Topics
 
-### Inspecting the state of the sampling server
+### Inspecting the state of the profile recording server
 
 - ``startResult``
 - ``ServerStartResult``

--- a/Sources/ProfileRecorderServer/Documentation.docc/Reference/ProfileRecorderServer.md
+++ b/Sources/ProfileRecorderServer/Documentation.docc/Reference/ProfileRecorderServer.md
@@ -15,36 +15,32 @@ First, add a dependency on ProfileRecorder:
     .product(name: "ProfileRecorderServer", package: "swipr"),
 ```
 
-Within your app, configure and run a sampling server, for example:
+Within your app, configure and run a profile recording server, for example:
 
 ```swift
 import ProfileRecorderServer
 
-do {
-    try await ProfileRecorderServer(
-        configuration: try await .parseFromEnvironment()
-    ).run(logger: logger)
-} catch {
-    logger.error("failed to start sampling server", metadata: ["error": "\(error)"])
-}
+await ProfileRecorderServer(
+    configuration: try await .parseFromEnvironment()
+).runIgnoringFailures(logger: logger)
 ```
 
-The `parseFromEnvironment()` function parses the `SWIPR_SAMPLING_SERVER_URL` & `SWIPR_SAMPLING_SERVER_URL_PATTERN`
+The `parseFromEnvironment()` function parses the `PROFILE_RECORDER_SERVER_URL` & `PROFILE_RECORDER_SERVER_URL_PATTERN`
 environment variables to configure the service.
 If you prefer to statically configure it, use:
 
 ```swift
-var samplingServerConfig = ProfileRecorderServerConfiguration.default
-samplingServerConfig.bindTarget = try SocketAddress(ipAddress: "127.0.0.0", port: 7377)
-try await ProfileRecorderServer(configuration: samplingServerConfig).run(logger: logger)
+var profilingServerConfig = ProfileRecorderServerConfiguration.default
+profilingServerConfig.bindTarget = try SocketAddress(ipAddress: "127.0.0.0", port: 7377)
+try await ProfileRecorderServer(configuration: profilingServerConfig).run(logger: logger)
 ```
 
 ### Production Configuration
 
 In production, it might be useful to use a UNIX Domain Socket instead of an HTTP server.
-If you have access to the filesystem where your app runs, such as a shell in a virtual machine or shell access to a restricted Kubernetes or Docker contrainersrentes pod, use the environment variable `SWIPR_SAMPLING_SERVER_URL_PATTERN` to define a UNIX domain socket to provide the traces.
+If you have access to the filesystem where your app runs, such as a shell in a virtual machine or shell access to a restricted Kubernetes or Docker contrainersrentes pod, use the environment variable `PROFILE_RECORDER_SERVER_URL_PATTERN` to define a UNIX domain socket to provide the traces.
 
-For example, set `SWIPR_SAMPLING_SERVER_URL_PATTERN="unix:///var/run/swipr-pid-{PID}.sock"`, and Swift Profile Recorder replaces the `{PID}` with the process id from your running app.
+For example, set `PROFILE_RECORDER_SERVER_URL_PATTERN="unix:///var/run/swipr-pid-{PID}.sock"`, and Swift Profile Recorder replaces the `{PID}` with the process id from your running app.
 In containerised environments, you get files called `/var/run/swipr-pid-1.sock` from this pattern that you can sample using the following command:
 
 ```bash
@@ -56,18 +52,19 @@ Drag the resulting file into [Firefox Profiler](https://profiler.firefox.com), a
 
 ## Topics
 
-### Creating a sampling server
+### Creating a profile recording server
 
 - ``init(configuration:)``
 - ``ProfileRecorderServerConfiguration``
 
-### Inspecting the sampling server
+### Inspecting the profile recording server
 
 - ``configuration``
 
-### Running the sampling server
+### Running the profile recording server
 
 - ``run(logger:)``
-- ``withSamplingServer(logger:_:)``
+- ``runIgnoringFailures(logger:)``
+- ``withProfileRecordingServer(logger:_:)``
 - ``ServerInfo``
 

--- a/Sources/swipr-mini-demo/Main.swift
+++ b/Sources/swipr-mini-demo/Main.swift
@@ -30,8 +30,8 @@ struct ProfileRecorderMiniDemo: ParsableCommand & Sendable {
     @Flag(inversion: .prefixedNo, help: "Should we burn do a bunch of Array.appends?")
     var arrayAppends: Bool = false
 
-    @Flag(inversion: .prefixedNo, help: "Start sampling server?")
-    var samplingServer: Bool = false
+    @Flag(inversion: .prefixedNo, help: "Start profile recording server?")
+    var profilingServer: Bool = false
 
     @Option(help: "How many samples?")
     var sampleCount: Int = 100
@@ -50,20 +50,20 @@ struct ProfileRecorderMiniDemo: ParsableCommand & Sendable {
 
     func run() throws {
         let logger = Logger(label: "swipr-mini-demo")
-        var samplingServerTask: Task<Void, any Error>? = nil
-        if self.samplingServer {
-            samplingServerTask = Task {
+        var profilingServerTask: Task<Void, any Error>? = nil
+        if self.profilingServer {
+            profilingServerTask = Task {
                 do {
                     try await ProfileRecorderServer(
                         configuration: try await .parseFromEnvironment()
                     ).run(logger: logger)
                 } catch {
-                    logger.error("failed to start sampling server", metadata: ["error": "\(error)"])
+                    logger.error("failed to start profile recording server", metadata: ["error": "\(error)"])
                 }
             }
         }
         defer {
-            samplingServerTask?.cancel()
+            profilingServerTask?.cancel()
         }
         ProfileRecorderSampler.sharedInstance.requestSamples(
             outputFilePath: self.output,

--- a/Tests/ProfileRecorderServerTests/ProfileRecorderServerTests.swift
+++ b/Tests/ProfileRecorderServerTests/ProfileRecorderServerTests.swift
@@ -22,7 +22,7 @@ final class ProfileRecorderServerTests: XCTestCase {
         let server = ProfileRecorderServer(
             configuration: try ProfileRecorderServerConfiguration.makeTCPListener(host: "127.0.0.1", port: 0)
         )
-        try await server.withSamplingServer(logger: Logger(label: "")) { server in
+        try await server.withProfileRecordingServer(logger: Logger(label: "")) { server in
             guard case .successful(let serverAddress) = server.startResult else {
                 XCTFail("failed to start server")
                 return
@@ -42,7 +42,7 @@ final class ProfileRecorderServerTests: XCTestCase {
         let server = ProfileRecorderServer(
             configuration: try ProfileRecorderServerConfiguration.makeTCPListener(host: "127.0.0.1", port: 0)
         )
-        try await server.withSamplingServer(logger: Logger(label: "")) { server in
+        try await server.withProfileRecordingServer(logger: Logger(label: "")) { server in
             guard case .successful(let serverAddress) = server.startResult else {
                 XCTFail("failed to start server")
                 return
@@ -95,7 +95,7 @@ final class ProfileRecorderServerTests: XCTestCase {
                     body: ByteBuffer(string: "hi")
                 )
         })
-        try await server.withSamplingServer(logger: Logger(label: "")) { server in
+        try await server.withProfileRecordingServer(logger: Logger(label: "")) { server in
             guard case .successful(let serverAddress) = server.startResult else {
                 XCTFail("failed to start server")
                 return

--- a/Tests/ProfileRecorderTests/ProfileRecorderTests.swift
+++ b/Tests/ProfileRecorderTests/ProfileRecorderTests.swift
@@ -34,7 +34,7 @@ final class ProfileRecorderTests: XCTestCase {
     var logger: Logger! = nil
 
     func testBasicJustRequestOneSample() throws {
-        guard ProfileRecorderSampler._isSupportedPlatformForTesting else {
+        guard ProfileRecorderSampler.isSupportedPlatform else {
             return
         }
 
@@ -46,7 +46,7 @@ final class ProfileRecorderTests: XCTestCase {
     }
 
     func testMultipleSamples() throws {
-        guard ProfileRecorderSampler._isSupportedPlatformForTesting else {
+        guard ProfileRecorderSampler.isSupportedPlatform else {
             return
         }
 
@@ -58,7 +58,7 @@ final class ProfileRecorderTests: XCTestCase {
     }
 
     func testSamplingWithALargeNumberOfThreads() throws {
-        guard ProfileRecorderSampler._isSupportedPlatformForTesting else {
+        guard ProfileRecorderSampler.isSupportedPlatform else {
             return
         }
 
@@ -76,7 +76,7 @@ final class ProfileRecorderTests: XCTestCase {
     }
 
     func testSamplingWhilstThreadsAreCreatedAndDying() throws {
-        guard ProfileRecorderSampler._isSupportedPlatformForTesting else {
+        guard ProfileRecorderSampler.isSupportedPlatform else {
             return
         }
 
@@ -98,7 +98,7 @@ final class ProfileRecorderTests: XCTestCase {
     // Experiencing issues due to the lack of frame pointers
     // (https://github.com/swiftlang/swift-corelibs-libdispatch/issues/909)
     func testSymbolicatedSamplesWork() async throws {
-        guard ProfileRecorderSampler._isSupportedPlatformForTesting else {
+        guard ProfileRecorderSampler.isSupportedPlatform else {
             return
         }
 
@@ -157,7 +157,7 @@ final class ProfileRecorderTests: XCTestCase {
     }
     
     func testSymbolsAreMangled() async throws {
-        guard ProfileRecorderSampler._isSupportedPlatformForTesting else {
+        guard ProfileRecorderSampler.isSupportedPlatform else {
             return
         }
 


### PR DESCRIPTION
- Update the recommended way of using it to simply `async let _ = ProfileRecorderServer(configuration: .parseFromEnvironment()).runIgnoringFailures(logger: logger)`
- Simplify the environment variables to `PROFILE_RECORDER_SERVER_URL_PATTERN` and `PROFILE_RECORDER_SERVER_URL`
- Align language to "profile recording server" (previously we used various different spellings)