### PR TITLE
shorten thread name to fit Linux's 16 char limit

### DIFF
--- a/Sources/CProfileRecorderSampler/sampler.c
+++ b/Sources/CProfileRecorderSampler/sampler.c
@@ -237,7 +237,7 @@ swipr_request_sample(FILE *output,
             (unsigned long long)current_time.tv_sec,
             (unsigned long long)current_time.tv_nsec);
 
-    swipr_os_dep_set_current_thread_name("ProfileRecorder-sampling");
+    swipr_os_dep_set_current_thread_name("swipr-sampling");
     for (size_t sample_no=0; sample_no<sample_count; sample_no++) {
         err = swipr_make_sample(minidumps, SWIPR_MAX_MUTATOR_THREADS, &num_minidumps);
         if (err) {


### PR DESCRIPTION
Whilst Profile Recorder is sampling the process, it renames the thread that controls the sampling. Currently it set it to `ProfileRecorder-sampling` but Linux has a 16 character limit for thread names, so it gets truncated.

Let's name it `swipr-sampling` (swipr for SWIft Profile Recorder) instead.

Please note, the intent is that nobody ever even sees this thread name because it won't appear in the samples (it filters out its own thread) and unless it's actively sampling it won't set that thread name. So the only time when you'd see this thread name is if you either sampled the process with an external profiler whilst also concurrently sampling with Profile Recorder at the same time. Or of course, in case Profile Recorder has a bug and crashes the process.