### PR TITLE
Logger metadata for duration of sampling and conversion

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     platforms: [
         // supported
         // Linux
-        .macOS(.v11),
+        .macOS(.v13),
 
         // not supported, listed to make compilation work
         .iOS(.v14),


### PR DESCRIPTION
Bumps macOS support to .v13 as Swift 5.10 is present.

Adds a logger metadata duration in the logs as shown in https://github.com/apple/swift-profile-recorder/issues/31

```
2025-10-07T09:11:49.423593 [...] ProfileRecorderSampleConversion/Sampler+Conversion.swift:61 : requesting raw samples ["raw-samples-path": /var/folders/zx/1np75sd15ygcssjxtfnq30xc0000gn/T/WYlcor8c/samples.raw, "symbolicated-samples-path": /var/folders/zx/1np75sd15ygcssjxtfnq30xc0000gn/T/WYlcor8c/samples.perf, "symbolizer": ProfileRecorderSampleConversion.CoreSymbolicationSymboliser, "sample-count": 3000, "time-between-samples": 10ms, "peer": [IPv4]127.0.0.1/127.0.0.1:64470]

2025-10-07T09:12:28.238699 [...] ProfileRecorderSampleConversion/Sampler+Conversion.swift:70 : raw samples complete ["raw-samples-path": /var/folders/zx/1np75sd15ygcssjxtfnq30xc0000gn/T/WYlcor8c/samples.raw, "symbolizer": ProfileRecorderSampleConversion.CoreSymbolicationSymboliser, "sample-count": 3000, "peer": [IPv4]127.0.0.1/127.0.0.1:64470, "duration": 38.814310791 seconds, "symbolicated-samples-path": /var/folders/zx/1np75sd15ygcssjxtfnq30xc0000gn/T/WYlcor8c/samples.perf, "time-between-samples": 10ms]

2025-10-07T09:12:36.587133 [...] ProfileRecorderSampleConversion/Sampler+Conversion.swift:97 : samples symbolicated duration ["raw-samples-path": /var/folders/zx/1np75sd15ygcssjxtfnq30xc0000gn/T/WYlcor8c/samples.raw, "symbolizer": ProfileRecorderSampleConversion.CoreSymbolicationSymboliser, "sample-count": 3000, "peer": [IPv4]127.0.0.1/127.0.0.1:64470, "duration": 8.348323542 seconds, "symbolicated-samples-path": /var/folders/zx/1np75sd15ygcssjxtfnq30xc0000gn/T/WYlcor8c/samples.perf, "time-between-samples": 10ms]
```