### PR TITLE
improve sample conversion speed

### DIFF
--- a/Sources/ProfileRecorderSampleConversion/HelperFunctions.swift
+++ b/Sources/ProfileRecorderSampleConversion/HelperFunctions.swift
@@ -20,3 +20,64 @@ import Foundation
 func swift_reportWarning(_ dunno: Int, _ message: String) {
     fputs("WARNING: \(message)\n", stderr)
 }
+
+extension Substring.UTF8View {
+    /// This is a very terrible JSON parser that should just about be able to parse a `StackFrame`
+    ///
+    /// - note: We are ignoring the stack pointer, so the stack pointer field will always be 0.
+    public func attemptFastParseStackFrame() -> StackFrame? {
+        enum State {
+            case beginning
+            case ipWaitingFor0x
+            case ipStartRange(String.Index, String.Index?)
+
+            var isWaitingFor0x: Bool {
+                if case .ipWaitingFor0x = self {
+                    return true
+                }
+                return false
+            }
+        }
+        var state: State = .beginning
+        let bytes = self
+        loop: for byteIndex in bytes.indices {
+            let byte = bytes[byteIndex]
+            switch byte {
+            case UInt8(ascii: "\""):
+                if case .ipStartRange(let start, .none) = state {
+                    state = .ipStartRange(start, byteIndex)
+                    break loop
+                }
+                continue
+            case UInt8(ascii: " "), UInt8(ascii: ":"), UInt8(ascii: "{"), UInt8(ascii: "}"),
+                UInt8(ascii: "p"):
+                // example line:
+                // {"ip": "0x18fe24c08", "sp": "0x1702a6fe0"}
+                // we ignore everything that's not an 'i', an 's' or hex digit like
+                // __i_____0x18fe24c08____s_____0x1702a6fe0
+                continue
+            case UInt8(ascii: "i"):
+                state = .ipWaitingFor0x
+            case UInt8(ascii: "0")...UInt8(ascii: "9"),
+                UInt8(ascii: "a")...UInt8(ascii: "f"),
+                UInt8(ascii: "A")...UInt8(ascii: "F"):
+                // ignore
+                continue
+            case UInt8(ascii: "x") where state.isWaitingFor0x:
+                state = .ipStartRange(bytes.index(after: byteIndex), nil)
+                break
+            default:
+                continue
+            }
+        }
+
+        if case .ipStartRange(let start, .some(let end)) = state {
+            guard let string = String(self[start..<end]), let ip = UInt(string, radix: 16) else {
+                return nil
+            }
+            return StackFrame(instructionPointer: ip, stackPointer: 0)
+        } else {
+            return nil
+        }
+    }
+}

--- a/Tests/ProfileRecorderSampleConversionTests/SampleConversionTests.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/SampleConversionTests.swift
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Profile Recorder open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Profile Recorder project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Profile Recorder project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import ProfileRecorderSampleConversion
+
+final class SampleConversionTests: XCTestCase {
+    func testBasicExample() {
+        let line = #"{"ip": "0x18fe24c08", "sp": "0x1702a6fe0"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0x1_8fe2_4c08, stackPointer: 0), actual)
+    }
+
+    func testZero() {
+        let line = #"{"ip": "0x0", "sp": "0x1702a6fe0"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0x0, stackPointer: 0), actual)
+    }
+
+    func testNoSpaces() {
+        let line = #"{"ip":"0x18fe24c08","sp":"0x1702a6fe0"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0x1_8fe2_4c08, stackPointer: 0), actual)
+    }
+
+    func testOrder() {
+        let line = #"{"sp":"0x1702a6fe0","ip":"0x18fe24c08"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0x1_8fe2_4c08, stackPointer: 0), actual)
+    }
+
+    func testExtraFieldsOrder() {
+        let line = #"{"sp":"0x1702a6fe0","unknown-field":"hello","ip":"0x18fe24c08"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0x1_8fe2_4c08, stackPointer: 0), actual)
+    }
+
+    func testSimpleCase() {
+        let line = #"{"ip":"0x18fe24c08","sp":"0x1702a6fe0"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0x1_8fe2_4c08, stackPointer: 0), actual)
+    }
+
+    func testIpFirst() {
+        let line = #"{"ip":"0xABCDEF","sp":"0x1702a6fe0"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0xABCDEF, stackPointer: 0), actual)
+    }
+
+    func testIpLast() {
+        let line = #"{"sp":"0x1234","thread":"42","flags":"0x9","ip":"0xCAFEBABE"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0xCAFE_BABE, stackPointer: 0), actual)
+    }
+
+    func testIpWithSpaces() {
+        let line = #"  {   "ip" :   "0xDEAD10CC" , "sp":"0x1702a6fe0" }  "#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0xDEAD_10CC, stackPointer: 0), actual)
+    }
+
+    func testIpMixedFields() {
+        let line = #"{"foo":1,"bar":true,"ip":"0x12345678","baz":[1,2,3]}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0x1234_5678, stackPointer: 0), actual)
+    }
+
+    func testIpEmbeddedInText() {
+        let line = #"{"message":"before","ip":"0xFEEDFACE","after":"something"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0xFEED_FACE, stackPointer: 0), actual)
+    }
+
+    func testIpUpperLowerMix() {
+        let line = #"{"ip":"0xDeadBeef"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0xDEAD_BEEF, stackPointer: 0), actual)
+    }
+
+    func testIpOnly() {
+        let line = #"{"ip":"0x11111111"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0x1111_1111, stackPointer: 0), actual)
+    }
+
+    func testIPWithEscapedString() {
+        let line = #"{"comment":"the ip is \"secret\"","ip":"0xFACEB00C"}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(StackFrame(instructionPointer: 0xFACE_B00C, stackPointer: 0), actual)
+    }
+
+    func testNoIPAtAll() {
+        let line = #"{"comment":"the ip is \"secret\""}"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(nil, actual)
+    }
+
+    func testPartialIP() {
+        let line = #"{"comment":"the ip is \"secret\"", "ip": "0x123"#[...]
+        let actual = line.utf8.attemptFastParseStackFrame()
+        XCTAssertEqual(nil, actual)
+    }
+}


### PR DESCRIPTION
### Motivation:

#31 showed that we spend a lot of time parsing the JSON for `.swipr` raw sample files. In particular, parsing lines like this

```
[SWIPR] STCK {"ip": "0x18fe24c08", "sp": "0x1702a6fe0"}
```

into `StackFrame(instructionPointer: 0x18fe24c08, stackPointer: whateverWeIgnoreItAnyway)` took over 50% of the time in my testing.

### Modification

Write a very bad but relatively fast hand-rolled JSON parser to make this a lot faster.

### Result

- fixes #31 

Before:

```
$ time .build/release/swipr-sample-conv  --use-fake-symbolizer true /tmp/huge.swipr > /tmp/hugefake.perf
2025-10-07T20:51:21+0100 info swipr-sample-conv: cached-sym=CachedSymbolizer(cache: 503, vmaps: 355, sym: FakeSymbolizer) [ProfileRecorderSampleConversion] done symbolising

real	0m23.742s
user	0m23.080s
sys	0m0.617s
```

After:

```
$ time .build/release/swipr-sample-conv  --use-fake-symbolizer true /tmp/huge.swipr > /tmp/hugefake.perf
2025-10-07T21:44:15+0100 info swipr-sample-conv: cached-sym=CachedSymbolizer(cache: 503, vmaps: 355, sym: FakeSymbolizer) [ProfileRecorderSampleConversion] done symbolising

real	0m9.394s
user	0m8.804s
sys	0m0.543s
```

-> more than 2x faster