### PR TITLE
fix warnings

### DIFF
--- a/Scripts/smoke-test.sh
+++ b/Scripts/smoke-test.sh
@@ -16,6 +16,7 @@ socket_path="$tmpdir/swipr.sock"
 PROFILE_RECORDER_SERVER_URL=unix://"$socket_path" \
     "$tmpdir"/build/release/swipr-mini-demo \
     --blocking --burn-cpu --array-appends \
+    --tsp true \
     --output "$output"/samples.swipr \
     --iterations 1000 \
     --profiling-server &

--- a/Sources/ProfileRecorderServer/Server.swift
+++ b/Sources/ProfileRecorderServer/Server.swift
@@ -319,9 +319,8 @@ public struct ProfileRecorderServer: Sendable {
         }
 
         let symbolizer = ProfileRecorderSampler._makeDefaultSymbolizer()
-        try symbolizer.start()
-        defer {
-            try! symbolizer.shutdown()
+        try await NIOThreadPool.singleton.runIfActive {
+            try symbolizer.start()
         }
 
         return try await asyncDo {
@@ -398,6 +397,9 @@ public struct ProfileRecorderServer: Sendable {
         } finally: { _ in
             if let udsPath = configuration.unixDomainSocketPath {
                 _ = try? await FileSystem.shared.removeItem(at: FilePath(udsPath))
+            }
+            try await NIOThreadPool.singleton.runIfActive {
+                try symbolizer.shutdown()
             }
         }
     }


### PR DESCRIPTION
Don't run symbolizer's potentially blocking `start`/`shutdown` methods on the Swift Concurrency thread pool.