### PR TITLE
Add Benchmark for conversions

### DIFF
--- a/Benchmarks/Benchmarks/ConversionBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/ConversionBenchmarks/Benchmarks.swift
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Profile Recorder open source project
+//
+// Copyright (c) 2021-2024 Apple Inc. and the Swift Profile Recorder project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Profile Recorder project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+import Foundation
+import Logging
+import NIO
+import ProfileRecorder
+import ProfileRecorderSampleConversion
+import SampleWorkload
+
+let benchmarks = {
+    Benchmark.defaultConfiguration = .init(
+        warmupIterations: 1,
+        maxDuration: .seconds(3)
+    )
+
+    let outputDir = "./output/conversion"
+    let arrayAppendProfilePath = outputDir.appending("/array-append.swipr")
+
+    LoggingSystem.bootstrap { label in
+        var handler = StreamLogHandler.standardError(label: label)
+        handler.logLevel = .warning
+        return handler
+    }
+
+    let logger = Logger(label: "benchmark")
+
+    Benchmark.setup = {
+        try FileManager.default.createDirectory(
+            at: URL(fileURLWithPath: outputDir),
+            withIntermediateDirectories: true
+        )
+
+        // create once a sample
+        if !FileManager.default.fileExists(atPath: arrayAppendProfilePath) {
+            Task {
+                let array = ArrayAppend(blocking: true, threads: 20)
+                array.run()
+            }
+
+            try await ProfileRecorderSampler.sharedInstance.requestSamples(
+                outputFilePath: arrayAppendProfilePath,
+                failIfFileExists: false,
+                count: 1000,
+                timeBetweenSamples: .milliseconds(1)
+            )
+        }
+    }
+
+    Benchmark("ArrayAppend FakeSymbolizer (PerfScript)") { benchmark in
+        let converter = ProfileRecorderSampleConverter(
+            config: SymbolizerConfiguration.default,
+            threadPool: .singleton,
+            group: .singletonMultiThreadedEventLoopGroup,
+            renderer: PerfScriptOutputRenderer(),
+            symbolizer: _ProfileRecorderFakeSymbolizer()
+        )
+
+        for _ in benchmark.scaledIterations {
+            try await converter.convert(
+                inputRawProfileRecorderFormatPath: arrayAppendProfilePath,
+                outputPath: outputDir.appending("/array-append.fake.perf"),
+                format: .pprofSymbolized,
+                logger: logger
+            )
+        }
+    }
+
+    Benchmark("ArrayAppend convert to PerfScript") { benchmark in
+        let symbolizer = ProfileRecorderSampler._makeDefaultSymbolizer()
+
+        try await NIOThreadPool.singleton.runIfActive {
+            try symbolizer.start()
+        }
+
+        let converter = ProfileRecorderSampleConverter(
+            config: SymbolizerConfiguration.default,
+            threadPool: .singleton,
+            group: .singletonMultiThreadedEventLoopGroup,
+            renderer: PerfScriptOutputRenderer(),
+            symbolizer: symbolizer
+        )
+
+        for _ in benchmark.scaledIterations {
+            try await converter.convert(
+                inputRawProfileRecorderFormatPath: arrayAppendProfilePath,
+                outputPath: outputDir.appending("/array-append.perf"),
+                format: .pprofSymbolized,
+                logger: logger
+            )
+        }
+        try? await NIOThreadPool.singleton.runIfActive {
+            try symbolizer.shutdown()
+        }
+    }
+
+    Benchmark("ArrayAppend convert to pprof") { benchmark in
+        let symbolizer = ProfileRecorderSampler._makeDefaultSymbolizer()
+
+        try await NIOThreadPool.singleton.runIfActive {
+            try symbolizer.start()
+        }
+
+        let converter = ProfileRecorderSampleConverter(
+            config: SymbolizerConfiguration.default,
+            threadPool: .singleton,
+            group: .singletonMultiThreadedEventLoopGroup,
+            renderer: PprofOutputRenderer(),
+            symbolizer: symbolizer
+        )
+
+        for _ in benchmark.scaledIterations {
+            try await converter.convert(
+                inputRawProfileRecorderFormatPath: arrayAppendProfilePath,
+                outputPath: outputDir.appending("/array-append.pprof"),
+                format: .pprofSymbolized,
+                logger: logger
+            )
+        }
+        try? await NIOThreadPool.singleton.runIfActive {
+            try symbolizer.shutdown()
+        }
+    }
+}

--- a/Benchmarks/Benchmarks/ConversionBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/ConversionBenchmarks/Benchmarks.swift
@@ -17,7 +17,7 @@ import Foundation
 import Logging
 import NIO
 import ProfileRecorder
-import ProfileRecorderSampleConversion
+import _ProfileRecorderSampleConversion
 import SampleWorkload
 
 let benchmarks = {

--- a/Benchmarks/Benchmarks/SampleWorkload/ArrayAppend.swift
+++ b/Benchmarks/Benchmarks/SampleWorkload/ArrayAppend.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Profile Recorder open source project
+//
+// Copyright (c) 2021-2024 Apple Inc. and the Swift Profile Recorder project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Profile Recorder project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+import Dispatch
+import Foundation
+
+public struct ArrayAppend {
+    var iterations: Int
+    var blocking: Bool
+    var threads: Int
+
+    public init(
+        iterations: Int = 4_000_000,
+        blocking: Bool = false,
+        threads: Int = 1
+    ) {
+        self.iterations = iterations
+        self.blocking = blocking
+        self.threads = threads
+    }
+
+    private func runIteration() {
+        var xs: [Int] = []
+        for x in 0..<iterations {
+            xs.append(x)
+        }
+        blackHole(xs)
+        if blocking {
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+    }
+
+    public func run() {
+        if threads > 1 {
+            let g = DispatchGroup()
+            let queue = DispatchQueue.global()
+            for _ in 0..<threads {
+                queue.async(group: g) {
+                    self.runIteration()
+                }
+            }
+            g.wait()
+        } else {
+            runIteration()
+        }
+    }
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .target(
             name: "SampleWorkload",
             dependencies: [
-                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "Benchmark", package: "package-benchmark")
             ],
             path: "Benchmarks/SampleWorkload",
         ),
@@ -44,6 +44,6 @@ let package = Package(
             plugins: [
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
             ]
-        )
+        ),
     ]
 )

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
                 "SampleWorkload",
                 .product(name: "Benchmark", package: "package-benchmark"),
                 .product(name: "ProfileRecorder", package: "swift-profile-recorder"),
-                .product(name: "ProfileRecorderSampleConversion", package: "swift-profile-recorder"),
+                .product(name: "_ProfileRecorderSampleConversion", package: "swift-profile-recorder"),
             ],
             path: "Benchmarks/ConversionBenchmarks",
             plugins: [

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,49 @@
+// swift-tools-version:5.10
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Profile Recorder open source project
+//
+// Copyright (c) 2021-2024 Apple Inc. and the Swift Profile Recorder project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Profile Recorder project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import PackageDescription
+
+let package = Package(
+    name: "benchmarks",
+    platforms: [
+        .macOS(.v14)
+    ],
+    dependencies: [
+        .package(path: "../"),
+        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.29.0"),
+    ],
+    targets: [
+        .target(
+            name: "SampleWorkload",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+            ],
+            path: "Benchmarks/SampleWorkload",
+        ),
+        .executableTarget(
+            name: "ConversionBenchmarks",
+            dependencies: [
+                "SampleWorkload",
+                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "ProfileRecorder", package: "swift-profile-recorder"),
+                .product(name: "ProfileRecorderSampleConversion", package: "swift-profile-recorder"),
+            ],
+            path: "Benchmarks/ConversionBenchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            ]
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
     products: [
         .library(name: "ProfileRecorder", targets: ["ProfileRecorder"]),
         .library(name: "ProfileRecorderServer", targets: ["ProfileRecorderServer"]),
+        .library(name: "ProfileRecorderSampleConversion", targets: ["ProfileRecorderSampleConversion"]),
         .executable(name: "swipr-sample-conv", targets: ["swipr-sample-conv"]),
     ],
     dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,7 @@ let package = Package(
         .target(
             name: "_ProfileRecorderSampleConversion",
             dependencies: [
-                "ProfileRecorderSampleConversion",
+                "ProfileRecorderSampleConversion"
             ]
         ),
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,9 @@ let package = Package(
     products: [
         .library(name: "ProfileRecorder", targets: ["ProfileRecorder"]),
         .library(name: "ProfileRecorderServer", targets: ["ProfileRecorderServer"]),
-        .library(name: "ProfileRecorderSampleConversion", targets: ["ProfileRecorderSampleConversion"]),
         .executable(name: "swipr-sample-conv", targets: ["swipr-sample-conv"]),
+        // _ProfileRecorderSampleConversion is not part of public API, internal benchmark use
+        .library(name: "_ProfileRecorderSampleConversion", targets: ["_ProfileRecorderSampleConversion"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
@@ -55,6 +56,12 @@ let package = Package(
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIOExtras", package: "swift-nio-extras"),
+            ]
+        ),
+        .target(
+            name: "_ProfileRecorderSampleConversion",
+            dependencies: [
+                "ProfileRecorderSampleConversion",
             ]
         ),
         .executableTarget(

--- a/Sources/_ProfileRecorderSampleConversion/_ProfileRecorderSampleConversion.swift
+++ b/Sources/_ProfileRecorderSampleConversion/_ProfileRecorderSampleConversion.swift
@@ -1,0 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Profile Recorder open source project
+//
+// Copyright (c) 2021-2025 Apple Inc. and the Swift Profile Recorder project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Profile Recorder project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// internal use only for benchmarks, not part of public API
+@_exported import ProfileRecorderSampleConversion


### PR DESCRIPTION
This adds [package-benchmark](https://github.com/ordo-one/package-benchmark) in order to be more easily measure the conversion optimisations; and to compare between branches for example.

The benchmark uses a simplified copied version of ArrayAppend; but some code refactoring for example code in swipr-mini-demo could be done to make the code usable in both locations.

```
$ swift package --package-path Benchmarks  --disable-sandbox benchmark
[...]
====================
ConversionBenchmarks
====================

ArrayAppend FakeSymbolizer (PerfScript)
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (G) *            │        11 │        11 │        11 │        11 │        11 │        11 │        11 │         4 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) (K) *          │       290 │       290 │       290 │       292 │      2301 │      2301 │      2301 │         4 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │       230 │       230 │       230 │       230 │       230 │       230 │       230 │         4 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Throughput (# / s) (#)        │         1 │         1 │         1 │         1 │         1 │         1 │         1 │         4 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (total CPU) (ms) *       │       851 │       851 │       854 │       859 │       861 │       861 │       861 │         4 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (ms) *      │       850 │       850 │       856 │       861 │       864 │       864 │       864 │         4 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

ArrayAppend convert to PerfScript
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (G) *            │        11 │        11 │        11 │        11 │        11 │        11 │        11 │         4 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) (K) *          │       334 │       334 │       335 │       335 │      4360 │      4360 │      4360 │         4 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        33 │        33 │        34 │        35 │        35 │        35 │        35 │         4 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Throughput (# / s) (#)        │         1 │         1 │         1 │         1 │         1 │         1 │         1 │         4 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (total CPU) (ms) *       │       870 │       870 │       871 │       876 │       878 │       878 │       878 │         4 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (ms) *      │       872 │       872 │       872 │       881 │       891 │       891 │       891 │         4 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

ArrayAppend convert to pprof
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (M) *            │      9526 │      9529 │      9529 │      9538 │      9550 │      9550 │      9550 │         5 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) (K) *          │      1642 │      1646 │      1646 │      3650 │      3652 │      3652 │      3652 │         5 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        34 │        34 │        35 │        36 │        36 │        36 │        36 │         5 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Throughput (# / s) (#)        │         1 │         1 │         1 │         1 │         1 │         1 │         1 │         5 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (total CPU) (ms) *       │       695 │       700 │       702 │       706 │       708 │       708 │       708 │         5 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (ms) *      │       696 │       703 │       704 │       708 │       709 │       709 │       709 │         5 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```


