### PR TITLE
Use `swift-protobuf` at `1.31.0` or newer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.1"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.80.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.24.1"),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.28.2"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.25.2"),
     ],
     targets: [


### PR DESCRIPTION
**Motivation**

The generated `.pb` files make use of `NameMap(bytecode:)` which got introduced by: https://github.com/apple/swift-protobuf/commit/0f043ac24a920257ef0a43768132acd1c24f008b#diff-ef685f44737aba259b8981adb12c31148e7a04cb88d048baefb4ac6440489e75R361, and therefore available in swift-protobuf 1.31.0 or newer.

**Changes**

* bump `swift-protobuf` dependency to 1.31.0+