### PR TITLE
Require `swift-protobuf` `1.31.1` and above

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.1"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.80.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.24.1"),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.0"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.25.2"),
     ],
     targets: [


### PR DESCRIPTION
**Motivation**

`swift-protobuf` introduced the ability to disable the binary targets using `PROTOBUF_NO_PROTOC` env variable. This came in with: https://github.com/apple/swift-protobuf/releases/tag/1.31.1. 

This feature is useful to be able to rely on but we need to adopt .1 patch for it.

This change is related to: https://github.com/apple/swift-profile-recorder/pull/36

**Changes**

* Bump `swift-protobuf` dependency version requirement from `1.31.0` to `1.31.1`.