### PR TITLE
sampler: support non-count based sampling

### DIFF
--- a/Sources/CProfileRecorderSampler/include/CSampler.h
+++ b/Sources/CProfileRecorderSampler/include/CSampler.h
@@ -17,9 +17,19 @@
 
 #include <unistd.h>
 #include <stdio.h>
+#include <stdbool.h>
 
-int swipr_request_sample(FILE *output,
-                         size_t sample_count,
+struct swipr_per_sample_information;
+
+size_t swipr_per_sample_information_get_samples_taken(struct swipr_per_sample_information * _Nonnull per_sample_info);
+
+int swipr_request_sample(FILE * _Nonnull output,
+                         bool (* _Nonnull should_take_more_samples)(
+                                                          void * _Nullable context,
+                                                          struct swipr_per_sample_information * _Nonnull per_sample_info
+                                                          ),
+                         void * _Nullable context,
+                         size_t sample_count_hint,
                          useconds_t usecs_between_samples);
 int swipr_initialize(void);
 

--- a/Sources/CProfileRecorderSampler/sampler.c
+++ b/Sources/CProfileRecorderSampler/sampler.c
@@ -192,15 +192,22 @@ swipr_make_sample(struct swipr_minidump *minidumps,
     return err;
 }
 
+struct swipr_per_sample_information {
+    size_t samples_taken;
+};
+
 int
 swipr_request_sample(FILE *output,
-                     size_t sample_count,
+                     bool (*should_take_more_samples)(void *, struct swipr_per_sample_information *),
+                     void *context,
+                     size_t sample_count_hint,
                      useconds_t usecs_between_samples) {
     size_t num_minidumps = 0;
     char old_thread_name[128] = {0};
     swipr_os_dep_get_current_thread_name(old_thread_name, sizeof(old_thread_name));
-    struct timespec current_time = swipr_sampler_get_current_time();
+    const struct timespec current_time = swipr_sampler_get_current_time();
     struct swipr_minidump *minidumps = NULL;
+    struct swipr_per_sample_information per_sample_info = {0};
 
 #if !defined(__linux__) && !defined(__APPLE__)
     fprintf(output,
@@ -225,25 +232,43 @@ swipr_request_sample(FILE *output,
         return err;
     }
 
-    fprintf(output,
-            "[SWIPR] CONF { "
-            "\"sampleCount\": %llu, "
-            "\"microSecondsBetweenSamples\": %llu, "
-            "\"currentTimeSeconds\": %llu, "
-            "\"currentTimeNanoseconds\": %llu, "
-            "}\n",
-            (unsigned long long)sample_count,
-            (unsigned long long)usecs_between_samples,
-            (unsigned long long)current_time.tv_sec,
-            (unsigned long long)current_time.tv_nsec);
+    if (sample_count_hint > 0) {
+        fprintf(output,
+                "[SWIPR] CONF { "
+                "\"sampleCount\": %llu, "
+                "\"microSecondsBetweenSamples\": %llu, "
+                "\"currentTimeSeconds\": %llu, "
+                "\"currentTimeNanoseconds\": %llu, "
+                "}\n",
+                (unsigned long long)sample_count_hint,
+                (unsigned long long)usecs_between_samples,
+                (unsigned long long)current_time.tv_sec,
+                (unsigned long long)current_time.tv_nsec
+                );
+    } else {
+        fprintf(output,
+                "[SWIPR] CONF { "
+                "\"microSecondsBetweenSamples\": %llu, "
+                "\"currentTimeSeconds\": %llu, "
+                "\"currentTimeNanoseconds\": %llu, "
+                "}\n",
+                (unsigned long long)usecs_between_samples,
+                (unsigned long long)current_time.tv_sec,
+                (unsigned long long)current_time.tv_nsec
+                );
+    }
 
     swipr_os_dep_set_current_thread_name("swipr-sampling");
-    for (size_t sample_no=0; sample_no<sample_count; sample_no++) {
+    for (
+         per_sample_info.samples_taken=0;
+         should_take_more_samples(context, &per_sample_info);
+         per_sample_info.samples_taken++
+    ) {
         err = swipr_make_sample(minidumps, SWIPR_MAX_MUTATOR_THREADS, &num_minidumps);
         if (err) {
             fprintf(output,
                     "[SWIPR] MESG { \"message\": \"Sample %lu failed, error: %d.\" }\n",
-                    sample_no, err);
+                    per_sample_info.samples_taken, err);
             continue;
         }
 
@@ -282,9 +307,20 @@ swipr_request_sample(FILE *output,
     }
     swipr_os_dep_set_current_thread_name(old_thread_name);
 
+    fprintf(output,
+            "[SWIPR] SMRY { "
+            "\"sampleCount\": %llu, "
+            "}\n",
+            (unsigned long long)per_sample_info.samples_taken
+            );
+
     free(minidumps);
     minidumps = NULL;
     return 0;
+}
+
+size_t swipr_per_sample_information_get_samples_taken(struct swipr_per_sample_information *per_sample_info) {
+    return per_sample_info->samples_taken;
 }
 
 static void

--- a/Sources/ProfileRecorder/ProfileRecorderSampler.swift
+++ b/Sources/ProfileRecorder/ProfileRecorderSampler.swift
@@ -37,6 +37,19 @@ struct ProfileRecorderSamplerError: Error {
     var code: CInt
 }
 
+struct ShouldSampleMoreCountBasedContext {
+    let desiredNumberOfSamples: Int
+}
+
+func shouldSampleMoreCountBased(
+    _ context: UnsafeMutableRawPointer?,
+    _ perSampleInfo: OpaquePointer
+) -> CBool {
+    let typedContext = context!.assumingMemoryBound(to: ShouldSampleMoreCountBasedContext.self)
+    let samplesTaken = swipr_per_sample_information_get_samples_taken(perSampleInfo)
+    return samplesTaken < typedContext.pointee.desiredNumberOfSamples
+}
+
 public final class ProfileRecorderSampler: Sendable {
     private let threadPool: NIOThreadPool
 
@@ -71,7 +84,14 @@ public final class ProfileRecorderSampler: Sendable {
     ) -> EventLoopFuture<Void> {
         #if canImport(CProfileRecorderSampler) // only on macOS & Linux
         return self.threadPool.runIfActive(eventLoop: eventLoop) {
-            let ret = swipr_request_sample(output.handle, .init(count), .init(timeBetweenSamples.nanoseconds / 1000))
+            var context = ShouldSampleMoreCountBasedContext(desiredNumberOfSamples: count)
+            let ret = swipr_request_sample(
+                output.handle,
+                shouldSampleMoreCountBased,
+                &context,
+                .init(count),
+                .init(timeBetweenSamples.nanoseconds / 1000)
+            )
             fflush(output.handle)
             guard ret == 0 else {
                 throw ProfileRecorderSamplerError(code: ret)

--- a/Sources/ProfileRecorderSampleConversion/Coders.swift
+++ b/Sources/ProfileRecorderSampleConversion/Coders.swift
@@ -28,7 +28,7 @@ public struct SampleConfig: Codable & Hashable & Sendable {
         currentTimeSeconds: Int,
         currentTimeNanoseconds: Int,
         microSecondsBetweenSamples: Int,
-        sampleCount: Int
+        sampleCount: Int?
     ) {
         self.currentTimeSeconds = currentTimeSeconds
         self.currentTimeNanoseconds = currentTimeNanoseconds
@@ -38,6 +38,14 @@ public struct SampleConfig: Codable & Hashable & Sendable {
     public var currentTimeSeconds: Int
     public var currentTimeNanoseconds: Int
     public var microSecondsBetweenSamples: Int
+    public var sampleCount: Optional<Int>
+}
+
+public struct SampleSummary: Codable & Hashable & Sendable {
+    public init(sampleCount: Int) {
+        self.sampleCount = sampleCount
+    }
+
     public var sampleCount: Int
 }
 

--- a/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/FlamegraphCollapsed.swift
+++ b/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/FlamegraphCollapsed.swift
@@ -46,6 +46,7 @@ public struct FlamegraphCollapsedOutputRenderer: ProfileRecorderSampleConversion
 
     public func finalise(
         sampleConfiguration: SampleConfig,
+        sampleSummary: SampleSummary,
         configuration: ProfileRecorderSampleConversionConfiguration,
         symbolizer: CachedSymbolizer
     ) -> ByteBuffer {

--- a/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/PerfScript.swift
+++ b/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/PerfScript.swift
@@ -73,6 +73,7 @@ public struct PerfScriptOutputRenderer: ProfileRecorderSampleConversionOutputRen
 
     public func finalise(
         sampleConfiguration: SampleConfig,
+        sampleSummary: SampleSummary,
         configuration: ProfileRecorderSampleConversionConfiguration,
         symbolizer: CachedSymbolizer
     ) -> ByteBuffer {

--- a/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/Pprof.swift
+++ b/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/Pprof.swift
@@ -35,6 +35,7 @@ public struct PprofOutputRenderer: ProfileRecorderSampleConversionOutputRenderer
 
     public mutating func finalise(
         sampleConfiguration: SampleConfig,
+        sampleSummary: SampleSummary,
         configuration: ProfileRecorderSampleConversionConfiguration,
         symbolizer: CachedSymbolizer
     ) throws -> ByteBuffer {
@@ -84,7 +85,7 @@ public struct PprofOutputRenderer: ProfileRecorderSampleConversionOutputRenderer
                 (Int64(sampleConfiguration.currentTimeSeconds) * 1_000_000_000)
                 + Int64(sampleConfiguration.currentTimeNanoseconds)
             profile.durationNanos =
-                Int64(sampleConfiguration.sampleCount) * Int64(sampleConfiguration.microSecondsBetweenSamples) * 1_000
+                Int64(sampleSummary.sampleCount) * Int64(sampleConfiguration.microSecondsBetweenSamples) * 1_000
             profile.period = Int64(sampleConfiguration.microSecondsBetweenSamples) * 1_000
 
             /*

--- a/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/RendererTypes.swift
+++ b/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/RendererTypes.swift
@@ -32,9 +32,51 @@ public protocol ProfileRecorderSampleConversionOutputRenderer: Sendable {
         symbolizer: CachedSymbolizer
     ) throws -> ByteBuffer
 
+    @available(*, deprecated, renamed: "finalise(sampleConfiguration:sampleSummary:configuration:symbolizer:)")
     mutating func finalise(
         sampleConfiguration: SampleConfig,
         configuration: ProfileRecorderSampleConversionConfiguration,
         symbolizer: CachedSymbolizer
     ) throws -> ByteBuffer
+
+    mutating func finalise(
+        sampleConfiguration: SampleConfig,
+        sampleSummary: SampleSummary,
+        configuration: ProfileRecorderSampleConversionConfiguration,
+        symbolizer: CachedSymbolizer
+    ) throws -> ByteBuffer
+}
+
+extension ProfileRecorderSampleConversionOutputRenderer {
+    @available(*, deprecated, renamed: "finalise(sampleConfiguration:sampleSummary:configuration:symbolizer:)")
+    public mutating func finalise(
+        sampleConfiguration: SampleConfig,
+        configuration: ProfileRecorderSampleConversionConfiguration,
+        symbolizer: CachedSymbolizer
+    ) throws -> ByteBuffer {
+        return try self.finalise(
+            sampleConfiguration: sampleConfiguration,
+            sampleSummary: SampleSummary(sampleCount: sampleConfiguration.sampleCount ?? 0),
+            configuration: configuration,
+            symbolizer: symbolizer
+        )
+    }
+
+    @available(
+        *,
+         deprecated,
+         message: "You must implement finalise(sampleConfiguration:sampleSummary:configuration:symbolizer:)"
+    )
+    public mutating func finalise(
+        sampleConfiguration: SampleConfig,
+        sampleSummary: SampleSummary,
+        configuration: ProfileRecorderSampleConversionConfiguration,
+        symbolizer: CachedSymbolizer
+    ) throws -> ByteBuffer {
+        return try self.finalise(
+            sampleConfiguration: sampleConfiguration,
+            configuration: configuration,
+            symbolizer: symbolizer
+        )
+    }
 }

--- a/Sources/ProfileRecorderSampleConversion/ProfileRecorderSampleConverter.swift
+++ b/Sources/ProfileRecorderSampleConversion/ProfileRecorderSampleConverter.swift
@@ -167,8 +167,9 @@ public struct ProfileRecorderSampleConverter: Sendable {
                 currentTimeSeconds: 0,
                 currentTimeNanoseconds: 0,
                 microSecondsBetweenSamples: 1,
-                sampleCount: 0
+                sampleCount: nil
             )
+            var sampleSummary = SampleSummary(sampleCount: 0)
             var vmaps: [DynamicLibMapping] = []
             var vmapsRead = true
             var currentSample: Sample? = nil
@@ -186,6 +187,7 @@ public struct ProfileRecorderSampleConverter: Sendable {
                     do {
                         let renderedSample = try self.renderer.finalise(
                             sampleConfiguration: sampleConfig,
+                            sampleSummary: sampleSummary,
                             configuration: config,
                             symbolizer: symboliser
                         )
@@ -236,6 +238,16 @@ public struct ProfileRecorderSampleConverter: Sendable {
                         continue
                     }
                     sampleConfig = conf
+                case "SMRY":
+                    guard
+                        let summary = try? decoder.decode(
+                            SampleSummary.self,
+                            from: Data(line.dropFirst(messageHeaderLength).utf8)
+                        )
+                    else {
+                        continue
+                    }
+                    sampleSummary = summary
                 case "VERS":
                     guard
                         let version = try? decoder.decode(

--- a/Sources/ProfileRecorderServer/Server.swift
+++ b/Sources/ProfileRecorderServer/Server.swift
@@ -336,7 +336,7 @@ public struct ProfileRecorderServer: Sendable {
                                     childGroup.addTask {
                                         var logger = logger
                                         if let remoteAddress = child.channel.remoteAddress {
-                                            logger[metadataKey: "peer"] = "\(child.channel.remoteAddress!)"
+                                            logger[metadataKey: "peer"] = "\(remoteAddress)"
                                         }
                                         do {
                                             logger.info("profile recorder server connection received")

--- a/Tests/ProfileRecorderSampleConversionTests/FlamegraphCollapsedTests.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/FlamegraphCollapsedTests.swift
@@ -33,6 +33,7 @@ final class FlamegraphCollapsedScriptTests: XCTestCase {
                     microSecondsBetweenSamples: 0,
                     sampleCount: 0
                 ),
+                sampleSummary: SampleSummary(sampleCount: 0),
                 configuration: .default,
                 symbolizer: self.symbolizer
             )
@@ -73,6 +74,7 @@ final class FlamegraphCollapsedScriptTests: XCTestCase {
                     microSecondsBetweenSamples: 0,
                     sampleCount: 0
                 ),
+                sampleSummary: SampleSummary(sampleCount: 0),
                 configuration: .default,
                 symbolizer: self.symbolizer
             )
@@ -113,6 +115,7 @@ final class FlamegraphCollapsedScriptTests: XCTestCase {
                     microSecondsBetweenSamples: 0,
                     sampleCount: 0
                 ),
+                sampleSummary: SampleSummary(sampleCount: 0),
                 configuration: .default,
                 symbolizer: self.symbolizer
             )

--- a/Tests/ProfileRecorderSampleConversionTests/PerfScriptTests.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/PerfScriptTests.swift
@@ -33,6 +33,7 @@ final class PerfScriptTests: XCTestCase {
                     microSecondsBetweenSamples: 0,
                     sampleCount: 0
                 ),
+                sampleSummary: SampleSummary(sampleCount: 0),
                 configuration: .default,
                 symbolizer: self.symbolizer
             )
@@ -76,6 +77,7 @@ final class PerfScriptTests: XCTestCase {
                     microSecondsBetweenSamples: 0,
                     sampleCount: 0
                 ),
+                sampleSummary: SampleSummary(sampleCount: 0),
                 configuration: .default,
                 symbolizer: self.symbolizer
             )

--- a/Tests/ProfileRecorderSampleConversionTests/PprofTests.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/PprofTests.swift
@@ -35,6 +35,7 @@ final class PprofTests: XCTestCase {
                         microSecondsBetweenSamples: 0,
                         sampleCount: 0
                     ),
+                    sampleSummary: SampleSummary(sampleCount: 0),
                     configuration: .default,
                     symbolizer: self.symbolizer
                 )

--- a/Tests/ProfileRecorderTests/ProfileRecorderTests.swift
+++ b/Tests/ProfileRecorderTests/ProfileRecorderTests.swift
@@ -84,7 +84,7 @@ final class ProfileRecorderTests: XCTestCase {
         )
     }
 
-    func testSamplingWithThreadThatBlocksSIGPROF() async throws {
+    func testSamplingWithThreadThatBlocksSIGPROF() throws {
         guard ProfileRecorderSampler.isSupportedPlatform else {
             return
         }
@@ -122,10 +122,12 @@ final class ProfileRecorderTests: XCTestCase {
         threadUnblock.signal()
         threadDone.wait()
 
-        let sampleData = try await ByteBuffer(
-            contentsOf: FilePath("\(self.tempDirectory!)/samples.samples"),
-            maximumSizeAllowed: .mebibytes(32)
-        )
+        let sampleData = try self.group.any().makeFutureWithTask { [tempDirectory = self.tempDirectory!] in
+            try await ByteBuffer(
+                contentsOf: FilePath("\(tempDirectory)/samples.samples"),
+                maximumSizeAllowed: .mebibytes(32)
+            )
+        }.wait()
         XCTAssertGreaterThan(sampleData.readableBytes, 0, "Sample file should not be empty")
         let sampleString = String(buffer: sampleData)
         XCTAssertTrue(sampleString.contains("[SWIPR] SMPL"), "Sample file should contain sample data")


### PR DESCRIPTION
This lays the groundwork for sampling that isn't count based. This is useful for sampling this is either time-based (sample for N seconds) or sampling that needs start/stop signals for sampling a specific piece of code.