### PR TITLE
Add per-thread labels to pprof output

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -173,6 +173,7 @@ let package = Package(
             dependencies: [
                 "ProfileRecorder",
                 "_ProfileRecorderSampleConversion",
+                "ProfileRecorderPprofFormat",
                 "ProfileRecorderHelpers",
                 .product(name: "Atomics", package: "swift-atomics"),
                 .product(name: "NIO", package: "swift-nio"),

--- a/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/Pprof.swift
+++ b/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/Pprof.swift
@@ -29,7 +29,8 @@ public struct PprofOutputRenderer: ProfileRecorderSampleConversionOutputRenderer
         let symbolisedStack = try sample.stack.map { frame in
             try symbolizer.symbolise(frame)
         }
-        self.aggregator.add(symbolisedStack)
+        let threadInfo = SampleAggregator.ThreadInfo(tid: sample.tid, name: sample.threadName)
+        self.aggregator.add(symbolisedStack, threadInfo: threadInfo)
         return ByteBuffer()
     }
 
@@ -46,6 +47,13 @@ public struct PprofOutputRenderer: ProfileRecorderSampleConversionOutputRenderer
         let countID = stringTable.addAndGetID("count", type: StringWithID.self)
         let cpuID = stringTable.addAndGetID("cpu", type: StringWithID.self)
         let nanosecondsID = stringTable.addAndGetID("nanoseconds", type: StringWithID.self)
+
+        // Thread label string table entries
+        let threadIDKeyID = stringTable.addAndGetID("thread_id", type: StringWithID.self)
+        let threadNameKeyID = stringTable.addAndGetID("thread_name", type: StringWithID.self)
+        for sampleKey in self.aggregator.samples.keys {
+            _ = stringTable.addAndGetID(sampleKey.threadInfo.name, type: StringWithID.self)
+        }
 
         let profile = Perftools_Profiles_Profile.with { profile in
             profile.location = self.aggregator.locations.values.sorted(by: { $0.id < $1.id }).map { location in
@@ -70,10 +78,26 @@ public struct PprofOutputRenderer: ProfileRecorderSampleConversionOutputRenderer
                     $0.unit = Int64(countID)
                 }
             ]
-            profile.sample = self.aggregator.samples.map { (inSample, count) in
+            profile.sample = self.aggregator.samples.map { (sampleKey, count) in
                 Perftools_Profiles_Sample.with { outSample in
-                    outSample.locationID = inSample.map { UInt64($0) }
+                    outSample.locationID = sampleKey.locationIDs.map { UInt64($0) }
                     outSample.value = [Int64(count)]
+                    outSample.label = [
+                        Perftools_Profiles_Label.with {
+                            $0.key = Int64(threadIDKeyID)
+                            $0.num = Int64(sampleKey.threadInfo.tid)
+                        },
+                        Perftools_Profiles_Label.with {
+                            if let entry = stringTable[sampleKey.threadInfo.name] {
+                                $0.key = Int64(threadNameKeyID)
+                                $0.str = Int64(entry.id)
+                            } else {
+                                assertionFailure(
+                                    "thread name '\(sampleKey.threadInfo.name)' missing from string table"
+                                )
+                            }
+                        },
+                    ]
                 }
             }
             profile.periodType = Perftools_Profiles_ValueType.with {

--- a/Sources/ProfileRecorderSampleConversion/SampleAggregator.swift
+++ b/Sources/ProfileRecorderSampleConversion/SampleAggregator.swift
@@ -42,12 +42,29 @@ struct SampleAggregator: Sendable {
             return new
         }
     }
+
+    struct ThreadInfo: Sendable, Hashable {
+        var tid: Int
+        var name: String
+    }
+
+    struct SampleKey: Sendable, Hashable {
+        var locationIDs: [Int]
+        var threadInfo: ThreadInfo
+    }
+
     var locations: [UInt: Location] = [:]
     var functions: [String: Function] = [:]
-    var samples: [[Int]: Int] = [:]
+    var samples: [SampleKey: Int] = [:]
 
-    mutating func add(_ sample: [SymbolisedStackFrame]) {
-        let locationIDs = sample.compactMap { stackFrame -> Int? in
+    mutating func add(_ sample: [SymbolisedStackFrame], threadInfo: ThreadInfo) {
+        let locationIDs = self.resolveLocationIDs(sample)
+        let key = SampleKey(locationIDs: locationIDs, threadInfo: threadInfo)
+        self.samples[key, default: 0] += 1
+    }
+
+    private mutating func resolveLocationIDs(_ sample: [SymbolisedStackFrame]) -> [Int] {
+        return sample.compactMap { stackFrame -> Int? in
             guard let address = stackFrame.allFrames.first?.address else {
                 assertionFailure("empty stack? \(stackFrame)")
                 return nil
@@ -67,7 +84,6 @@ struct SampleAggregator: Sendable {
             )
             return nextID
         }
-        self.samples[locationIDs, default: 0] += 1
     }
 }
 

--- a/Sources/ProfileRecorderSampleConversion/Symboliser.swift
+++ b/Sources/ProfileRecorderSampleConversion/Symboliser.swift
@@ -257,7 +257,9 @@ public struct SymbolizerConfiguration: Sendable {
     public var perfScriptOutputWithFileLineInformation: Bool
 
     public static var `default`: SymbolizerConfiguration {
-        return SymbolizerConfiguration(perfScriptOutputWithFileLineInformation: false)
+        return SymbolizerConfiguration(
+            perfScriptOutputWithFileLineInformation: false
+        )
     }
 }
 

--- a/Tests/ProfileRecorderSampleConversionTests/CachedSymbolizerTests.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/CachedSymbolizerTests.swift
@@ -67,7 +67,7 @@ final class CachedSymbolizerTests: XCTestCase {
         self.underlyingSymbolizer = FakeSymbolizer()
         try self.underlyingSymbolizer!.start()
         self.symbolizer = CachedSymbolizer(
-            configuration: SymbolizerConfiguration(perfScriptOutputWithFileLineInformation: false),
+            configuration: .default,
             symbolizer: self.underlyingSymbolizer!,
             dynamicLibraryMappings: [
                 DynamicLibMapping(

--- a/Tests/ProfileRecorderSampleConversionTests/FlamegraphCollapsedTests.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/FlamegraphCollapsedTests.swift
@@ -151,7 +151,7 @@ final class FlamegraphCollapsedScriptTests: XCTestCase {
         self.underlyingSymbolizer = FakeSymbolizer()
         try self.underlyingSymbolizer!.start()
         self.symbolizer = CachedSymbolizer(
-            configuration: SymbolizerConfiguration(perfScriptOutputWithFileLineInformation: false),
+            configuration: .default,
             symbolizer: self.underlyingSymbolizer!,
             dynamicLibraryMappings: [
                 DynamicLibMapping(

--- a/Tests/ProfileRecorderSampleConversionTests/Helpers.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/Helpers.swift
@@ -48,8 +48,8 @@ final class FakeSymbolizer: Symbolizer {
 }
 
 extension Perftools_Profiles_Profile {
-    static func from(_ buffer: ByteBuffer) throws -> Self {
         var buf = buffer
         return try Self(serializedBytes: buf.readBytes(length: buf.readableBytes)!)
+    init(_ buffer: ByteBuffer) throws {
     }
 }

--- a/Tests/ProfileRecorderSampleConversionTests/Helpers.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/Helpers.swift
@@ -48,8 +48,7 @@ final class FakeSymbolizer: Symbolizer {
 }
 
 extension Perftools_Profiles_Profile {
-        var buf = buffer
-        return try Self(serializedBytes: buf.readBytes(length: buf.readableBytes)!)
     init(_ buffer: ByteBuffer) throws {
+        try self.init(serializedBytes: Array(buffer.readableBytesView))
     }
 }

--- a/Tests/ProfileRecorderSampleConversionTests/Helpers.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/Helpers.swift
@@ -14,6 +14,8 @@
 
 import _ProfileRecorderSampleConversion
 import Logging
+import NIO
+import ProfileRecorderPprofFormat
 
 final class FakeSymbolizer: Symbolizer {
     var description: String {
@@ -42,5 +44,12 @@ final class FakeSymbolizer: Symbolizer {
     }
 
     func shutdown() throws {
+    }
+}
+
+extension Perftools_Profiles_Profile {
+    static func from(_ buffer: ByteBuffer) throws -> Self {
+        var buf = buffer
+        return try Self(serializedBytes: buf.readBytes(length: buf.readableBytes)!)
     }
 }

--- a/Tests/ProfileRecorderSampleConversionTests/PerfScriptTests.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/PerfScriptTests.swift
@@ -117,7 +117,7 @@ final class PerfScriptTests: XCTestCase {
         self.underlyingSymbolizer = FakeSymbolizer()
         try self.underlyingSymbolizer!.start()
         self.symbolizer = CachedSymbolizer(
-            configuration: SymbolizerConfiguration(perfScriptOutputWithFileLineInformation: false),
+            configuration: .default,
             symbolizer: self.underlyingSymbolizer!,
             dynamicLibraryMappings: [
                 DynamicLibMapping(

--- a/Tests/ProfileRecorderSampleConversionTests/PprofTests.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/PprofTests.swift
@@ -88,7 +88,7 @@ final class PprofTests: XCTestCase {
             configuration: .default,
             symbolizer: self.symbolizer
         )
-        let profile = try Perftools_Profiles_Profile.from(output)
+        let profile = try Perftools_Profiles_Profile(output)
         XCTAssertEqual(profile.sample.count, 1)
         XCTAssertEqual(profile.sample[0].label.count, 2, "Should have thread_id and thread_name labels")
     }
@@ -117,7 +117,7 @@ final class PprofTests: XCTestCase {
             configuration: .default,
             symbolizer: self.symbolizer
         )
-        let profile = try Perftools_Profiles_Profile.from(output)
+        let profile = try Perftools_Profiles_Profile(output)
         XCTAssertEqual(profile.sample.count, 2, "Same stack from different threads should NOT be aggregated")
     }
 
@@ -145,7 +145,7 @@ final class PprofTests: XCTestCase {
             configuration: .default,
             symbolizer: self.symbolizer
         )
-        let profile = try Perftools_Profiles_Profile.from(output)
+        let profile = try Perftools_Profiles_Profile(output)
         XCTAssertEqual(profile.sample.count, 1, "Same stack from same thread should be aggregated")
         XCTAssertEqual(profile.sample[0].value, [3])
     }
@@ -172,7 +172,7 @@ final class PprofTests: XCTestCase {
             configuration: .default,
             symbolizer: self.symbolizer
         )
-        let profile = try Perftools_Profiles_Profile.from(output)
+        let profile = try Perftools_Profiles_Profile(output)
         XCTAssertEqual(profile.sample.count, 1)
 
         let sample = profile.sample[0]
@@ -218,7 +218,7 @@ final class PprofTests: XCTestCase {
             configuration: .default,
             symbolizer: self.symbolizer
         )
-        let profile = try Perftools_Profiles_Profile.from(output)
+        let profile = try Perftools_Profiles_Profile(output)
         XCTAssertEqual(profile.sample.count, 3)
         let emittedNames = Set(
             profile.sample.compactMap { sample -> String? in

--- a/Tests/ProfileRecorderSampleConversionTests/PprofTests.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/PprofTests.swift
@@ -15,6 +15,7 @@
 import Logging
 import XCTest
 import NIO
+import ProfileRecorderPprofFormat
 
 @testable import _ProfileRecorderSampleConversion
 
@@ -63,6 +64,171 @@ final class PprofTests: XCTestCase {
         XCTAssertEqual(ByteBuffer(), actual)
     }
 
+    func testPprofBasicDeserializesCorrectly() throws {
+        var renderer = PprofOutputRenderer()
+        let _ = try renderer.consumeSingleSample(
+            Sample(
+                sampleHeader: SampleHeader(pid: 1, tid: 2, name: "thread", timeSec: 4, timeNSec: 5),
+                stack: [
+                    StackFrame(instructionPointer: 0, stackPointer: .max),
+                    StackFrame(instructionPointer: 0x2345, stackPointer: .max),
+                    StackFrame(instructionPointer: 0x2999, stackPointer: .max),
+                ]
+            ),
+            configuration: .default,
+            symbolizer: self.symbolizer
+        )
+        let output = try renderer.finalise(
+            sampleConfiguration: SampleConfig(
+                currentTimeSeconds: 0,
+                currentTimeNanoseconds: 0,
+                microSecondsBetweenSamples: 0,
+                sampleCount: 0
+            ),
+            configuration: .default,
+            symbolizer: self.symbolizer
+        )
+        let profile = try Perftools_Profiles_Profile.from(output)
+        XCTAssertEqual(profile.sample.count, 1)
+        XCTAssertEqual(profile.sample[0].label.count, 2, "Should have thread_id and thread_name labels")
+    }
+
+    func testPprofSameStackDifferentThreads_NotAggregated() throws {
+        var renderer = PprofOutputRenderer()
+        for tid in [10, 20] {
+            let _ = try renderer.consumeSingleSample(
+                Sample(
+                    sampleHeader: SampleHeader(pid: 1, tid: tid, name: "T\(tid)", timeSec: 0, timeNSec: 0),
+                    stack: [
+                        StackFrame(instructionPointer: 0x2345, stackPointer: .max)
+                    ]
+                ),
+                configuration: .default,
+                symbolizer: self.symbolizer
+            )
+        }
+        let output = try renderer.finalise(
+            sampleConfiguration: SampleConfig(
+                currentTimeSeconds: 0,
+                currentTimeNanoseconds: 0,
+                microSecondsBetweenSamples: 0,
+                sampleCount: 0
+            ),
+            configuration: .default,
+            symbolizer: self.symbolizer
+        )
+        let profile = try Perftools_Profiles_Profile.from(output)
+        XCTAssertEqual(profile.sample.count, 2, "Same stack from different threads should NOT be aggregated")
+    }
+
+    func testPprofSameStackSameThread_Aggregated() throws {
+        var renderer = PprofOutputRenderer()
+        for _ in 0..<3 {
+            let _ = try renderer.consumeSingleSample(
+                Sample(
+                    sampleHeader: SampleHeader(pid: 1, tid: 42, name: "worker", timeSec: 0, timeNSec: 0),
+                    stack: [
+                        StackFrame(instructionPointer: 0x2345, stackPointer: .max)
+                    ]
+                ),
+                configuration: .default,
+                symbolizer: self.symbolizer
+            )
+        }
+        let output = try renderer.finalise(
+            sampleConfiguration: SampleConfig(
+                currentTimeSeconds: 0,
+                currentTimeNanoseconds: 0,
+                microSecondsBetweenSamples: 0,
+                sampleCount: 0
+            ),
+            configuration: .default,
+            symbolizer: self.symbolizer
+        )
+        let profile = try Perftools_Profiles_Profile.from(output)
+        XCTAssertEqual(profile.sample.count, 1, "Same stack from same thread should be aggregated")
+        XCTAssertEqual(profile.sample[0].value, [3])
+    }
+
+    func testPprofHasCorrectThreadLabels() throws {
+        var renderer = PprofOutputRenderer()
+        let _ = try renderer.consumeSingleSample(
+            Sample(
+                sampleHeader: SampleHeader(pid: 1, tid: 42, name: "main-thread", timeSec: 0, timeNSec: 0),
+                stack: [
+                    StackFrame(instructionPointer: 0x2345, stackPointer: .max)
+                ]
+            ),
+            configuration: .default,
+            symbolizer: self.symbolizer
+        )
+        let output = try renderer.finalise(
+            sampleConfiguration: SampleConfig(
+                currentTimeSeconds: 0,
+                currentTimeNanoseconds: 0,
+                microSecondsBetweenSamples: 0,
+                sampleCount: 0
+            ),
+            configuration: .default,
+            symbolizer: self.symbolizer
+        )
+        let profile = try Perftools_Profiles_Profile.from(output)
+        XCTAssertEqual(profile.sample.count, 1)
+
+        let sample = profile.sample[0]
+        XCTAssertEqual(sample.label.count, 2)
+
+        let threadIDLabel = sample.label.first { profile.stringTable[Int($0.key)] == "thread_id" }
+        XCTAssertNotNil(threadIDLabel)
+        XCTAssertEqual(threadIDLabel?.num, 42)
+
+        let threadNameLabel = sample.label.first { profile.stringTable[Int($0.key)] == "thread_name" }
+        XCTAssertNotNil(threadNameLabel)
+        XCTAssertEqual(profile.stringTable[Int(threadNameLabel!.str)], "main-thread")
+    }
+
+    func testPprofThreadNameStringTableLookupIsSafe() throws {
+        var renderer = PprofOutputRenderer()
+        let threadNames = ["", "NIO-ELT-0-#3", "worker-pool-7"]
+        for (index, name) in threadNames.enumerated() {
+            let _ = try renderer.consumeSingleSample(
+                Sample(
+                    sampleHeader: SampleHeader(
+                        pid: 1,
+                        tid: index + 1,
+                        name: name,
+                        timeSec: 0,
+                        timeNSec: 0
+                    ),
+                    stack: [
+                        StackFrame(instructionPointer: 0x2345, stackPointer: .max)
+                    ]
+                ),
+                configuration: .default,
+                symbolizer: self.symbolizer
+            )
+        }
+        let output = try renderer.finalise(
+            sampleConfiguration: SampleConfig(
+                currentTimeSeconds: 0,
+                currentTimeNanoseconds: 0,
+                microSecondsBetweenSamples: 0,
+                sampleCount: 0
+            ),
+            configuration: .default,
+            symbolizer: self.symbolizer
+        )
+        let profile = try Perftools_Profiles_Profile.from(output)
+        XCTAssertEqual(profile.sample.count, 3)
+        let emittedNames = Set(
+            profile.sample.compactMap { sample -> String? in
+                let label = sample.label.first { profile.stringTable[Int($0.key)] == "thread_name" }
+                return label.map { profile.stringTable[Int($0.str)] }
+            }
+        )
+        XCTAssertEqual(emittedNames, Set(threadNames))
+    }
+
     // MARK: - Setup/teardown
     override func setUpWithError() throws {
         self.logger = Logger(label: "\(Self.self)")
@@ -71,7 +237,7 @@ final class PprofTests: XCTestCase {
         self.underlyingSymbolizer = FakeSymbolizer()
         try self.underlyingSymbolizer!.start()
         self.symbolizer = CachedSymbolizer(
-            configuration: SymbolizerConfiguration(perfScriptOutputWithFileLineInformation: false),
+            configuration: .default,
             symbolizer: self.underlyingSymbolizer!,
             dynamicLibraryMappings: [
                 DynamicLibMapping(


### PR DESCRIPTION
Pprof samples now carry `thread_id` (numeric) and `thread_name` (string) labels. Identical stacks from different threads are kept as separate samples rather than merged.

### Callouts

- `SampleAggregator`: new `ThreadInfo` and `SampleKey` types; aggregation is now keyed by stack + thread identity.
- `PprofOutputRenderer`: populates `thread_id` and `thread_name` labels on every sample.