### PR TITLE
Populate `Location.address` in `Pprof` renderer

### DIFF
--- a/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/Pprof.swift
+++ b/Sources/ProfileRecorderSampleConversion/OutputFormatRendering/Pprof.swift
@@ -59,6 +59,7 @@ public struct PprofOutputRenderer: ProfileRecorderSampleConversionOutputRenderer
             profile.location = self.aggregator.locations.values.sorted(by: { $0.id < $1.id }).map { location in
                 .with {
                     $0.id = UInt64(location.id)
+                    $0.address = UInt64(location.address)
                     $0.line = location.functions.map { functionID in
                         .with {
                             $0.functionID = UInt64(functionID)

--- a/Tests/ProfileRecorderSampleConversionTests/PprofTests.swift
+++ b/Tests/ProfileRecorderSampleConversionTests/PprofTests.swift
@@ -91,6 +91,13 @@ final class PprofTests: XCTestCase {
         let profile = try Perftools_Profiles_Profile(output)
         XCTAssertEqual(profile.sample.count, 1)
         XCTAssertEqual(profile.sample[0].label.count, 2, "Should have thread_id and thread_name labels")
+
+        let nonZeroAddressLocations = profile.location.filter { $0.address != 0 }
+        XCTAssertEqual(
+            nonZeroAddressLocations.count,
+            2,
+            "Both valid instruction pointers should produce locations with addresses"
+        )
     }
 
     func testPprofSameStackDifferentThreads_NotAggregated() throws {


### PR DESCRIPTION
The aggregator's `Location` already has the pointer address but we weren't using it during rendering.