### PR TITLE
Fixed Static Linux SDK build by importing Musl instead of Glibc when applicable

### DIFF
--- a/Sources/ProfileRecorder/ProfileRecorderSampler.swift
+++ b/Sources/ProfileRecorder/ProfileRecorderSampler.swift
@@ -14,7 +14,10 @@
 
 #if canImport(Glibc)
 @preconcurrency import Glibc // Sendability of stdout/stderr/..., needs to be at the top of the file
+#elseif canImport(Musl)
+@preconcurrency import Musl
 #endif
+
 import NIO
 import _NIOFileSystem
 import Dispatch

--- a/Sources/ProfileRecorderSampleConversion/HelperFunctions.swift
+++ b/Sources/ProfileRecorderSampleConversion/HelperFunctions.swift
@@ -14,7 +14,10 @@
 
 #if canImport(Glibc)
 @preconcurrency import Glibc // Sendability of stdout/stderr/..., needs to be at the top of the file
+#elseif canImport(Musl)
+@preconcurrency import Musl
 #endif
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/swipr-sample-conv/LLVMJSONOutputParserHandler.swift
+++ b/Sources/swipr-sample-conv/LLVMJSONOutputParserHandler.swift
@@ -14,7 +14,10 @@
 
 #if canImport(Glibc)
 @preconcurrency import Glibc // Sendability of stdout/stderr/..., needs to be at the top of the file
+#elseif canImport(Musl)
+@preconcurrency import Musl
 #endif
+
 import NIO
 import NIOFoundationCompat
 import Foundation

--- a/Sources/swipr-sample-conv/LLVMOutputParserHandler.swift
+++ b/Sources/swipr-sample-conv/LLVMOutputParserHandler.swift
@@ -14,7 +14,10 @@
 
 #if canImport(Glibc)
 @preconcurrency import Glibc // Sendability of stdout/stderr/..., needs to be at the top of the file
+#elseif canImport(Musl)
+@preconcurrency import Musl
 #endif
+
 import NIO
 import _ProfileRecorderSampleConversion
 

--- a/Sources/swipr-sample-conv/LLVMSymbolizer.swift
+++ b/Sources/swipr-sample-conv/LLVMSymbolizer.swift
@@ -14,7 +14,10 @@
 
 #if canImport(Glibc)
 @preconcurrency import Glibc // Sendability of stdout/stderr/..., needs to be at the top of the file
+#elseif canImport(Musl)
+@preconcurrency import Musl
 #endif
+
 import _ProfileRecorderSampleConversion
 import NIO
 import Foundation

--- a/Sources/swipr-sample-conv/MainFile.swift
+++ b/Sources/swipr-sample-conv/MainFile.swift
@@ -14,7 +14,10 @@
 
 #if canImport(Glibc)
 @preconcurrency import Glibc // Sendability of stdout/stderr/..., needs to be at the top of the file
+#elseif canImport(Musl)
+@preconcurrency import Musl
 #endif
+
 import ArgumentParser
 import Foundation
 import NIO


### PR DESCRIPTION
For the cases where Glibc alone was conditionally imported (no fallback) and annotated with `@preconcurrency`:

```swift
#if canImport(Glibc)
@preconcurrency import Glibc // Sendability of stdout/stderr/..., needs to be at the top of the file
#endif
```

I decided to expand it like so:

```swift
#if canImport(Glibc)
@preconcurrency import Glibc // Sendability of stdout/stderr/..., needs to be at the top of the file
#elseif canImport(Musl)
@preconcurrency import Musl
#endif
```

This replacement was applied to all matching source files.

Tested on a Linux container:

```sh
 docker run --rm -it -v $PWD:/opt/src swift
```

Install the SDK:

```sh
swift sdk install https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz --checksum 3fd798bef6f4408f1ea5a6f94ce4d4052830c4326ab85ebc04f983f01b3da407
```

Verification:

<img width="623" height="197" alt="image" src="https://github.com/user-attachments/assets/1f449089-3e96-47f0-9dda-af907467786e" />
